### PR TITLE
Add cluster name to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ resource "random_string" "password" {
 | client_certificate | Base64 encoded public certificate used by clients to authenticate to the cluster endpoint |
 | client_key | Base64 encoded private key used by clients to authenticate to the cluster endpoint |
 | cluster_ca_certificate | Base64 encoded public certificate that is the root of trust for the cluster |
+| cluster_name | The full name of this Kubernetes cluster |
 | endpoint | The IP address of this cluster's Kubernetes master |
 | gcr_url | This data source fetches the project name, and provides the appropriate URLs to use for container registry for this project |
 | instance_group_urls | List of instance group URLs which have been assigned to the cluster |

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,6 +43,11 @@ output "cluster_ca_certificate" {
   description = "Base64 encoded public certificate that is the root of trust for the cluster"
 }
 
+output "cluster_name" {
+  value       =  "${google_container_cluster.new_container_cluster.name}"
+  description =  "The full name of this Kubernetes cluster"
+}
+
 output "gcr_url" {
   value       = "${data.google_container_registry_repository.registry.repository_url}"
   description = "This data source fetches the project name, and provides the appropriate URLs to use for container registry for this project"


### PR DESCRIPTION
Expose the new Kubernetes cluster name so that credentials can be fetched using `gcloud`.