### PR TITLE
Extra parameters to node_config 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,11 +23,22 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
   cluster    = "${google_container_cluster.new_container_cluster.name}"
 
   node_config {
-    preemptible     = "${lookup(var.node_pool[count.index], "preemptible", false)}"
-    machine_type    = "${lookup(var.node_pool[count.index], "machine_type", "n1-standard-1")}"
     disk_size_gb    = "${lookup(var.node_pool[count.index], "disk_size_gb", 10)}"
+    disk_type       = "${lookup(var.node_pool[count.index], "disk_type", "pd-standard")}"
+    image_type      = "${lookup(var.node_pool[count.index], "image", "COS")}"
     local_ssd_count = "${lookup(var.node_pool[count.index], "local_ssd_count", 0)}"
+    machine_type    = "${lookup(var.node_pool[count.index], "machine_type", "n1-standard-1")}"
+
     oauth_scopes    = "${split(",", lookup(var.node_pool[count.index], "oauth_scopes", "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring"))}"
+    preemptible     = "${lookup(var.node_pool[count.index], "preemptible", false)}"
+    service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
+    labels          = "${var.labels}"
+    tags            = "${var.tags}"
+    metadata        = "${var.metadata}"
+
+    workload_metadata_config {
+      node_metadata = "${lookup(var.node_pool[count.index], "node_metadata", "EXPOSE")}"
+    }
   }
 
   autoscaling {


### PR DESCRIPTION
Added parameters to node_config so the default_pool matches extra pools, solves issue with removing the default pool and having mismatched parameters forcing terraform to recreate in the case:

```
  default_node_pool = {
    machine_type     = "${var.node_machine_type}"
    disk_size_gb     = "${var.node_disk_size}"
    node_count       = "${var.initial_node_count}"
    remove           = true
  }

  # Optional in case we have a default pool
  node_pool = [
    {
      machine_type   = "${var.node_machine_type}"
      disk_size_gb   = "${var.node_disk_size}"
      node_count     = "${var.initial_node_count}"
      min_node_count = "${var.min_node_count}"
      max_node_count = "${var.max_node_count}"
    }
  ]
```

```
      node_config.0.workload_metadata_config.#:                   "0" => "1" (forces new resource)
      node_config.0.workload_metadata_config.0.node_metadata:     "" => "EXPOSE" (forces new resource)
```


