### PR TITLE
Add more information to node_count settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ module "gke-cluster" {
   }
 
   # Optional in case we have a default pool
+  #
+  # Note that all node_count settings are applied per-zone
+  # (i.e. min_node_count 2 with 3 zones will create a node pool with 
+  #	min_node_count 6)
   node_pool = [
     {
       machine_type   = "g1-small"


### PR DESCRIPTION
The current documentation may make users think that node_count settings
are applied on a node pool level, but they are actually applied at a
zonal level.